### PR TITLE
[RFR] fix/current-year-fn

### DIFF
--- a/src/components/footer/footer.js
+++ b/src/components/footer/footer.js
@@ -1,12 +1,12 @@
 import React from "react"
-import { getCurrentYear } from "./../../utils"
+import { getYear } from "./../../utils"
 import "./footer.scss"
 
 // Footer :: Props -> React.Component
 const Footer = () =>
   <footer className="container">
     <p>
-      © {getCurrentYear()} Amaury Langlois
+      © {getYear(new Date())} Amaury Langlois
       <span className="is-hidden-mobile">/</span>
     </p>
     <p>

--- a/src/utils.js
+++ b/src/utils.js
@@ -31,8 +31,8 @@ export const findIndexByTitle = uncurryN(2, title => pipe(
 
 // Date utils //////////////////////////////////////////////////////////////////
 
-// getCurrentYear :: () -> Number
-export const getCurrentYear = () => (new Date()).getFullYear()
+// getYear :: Date -> Number
+export const getYear = date => date.getFullYear();
 
 // toFrenchDate :: (Date, Object) -> String
 export const toFrenchDate = (date, options) => date.toLocaleDateString(

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -30,8 +30,8 @@ describe("miscellaneous utils", () => {
 
 describe("date utils", () =>  {
   it("determines the current year", () => pipe(
-    result => expect(result).toBe(2021),
-  )(utils.getCurrentYear()))
+    result => expect(result).toBe(1992),
+  )(utils.getYear(new Date("1992-09-27"))))
 
   it("formats a date in french", () => pipe(
     date => new Date(date),


### PR DESCRIPTION
This PR introduces changes on the getCurrentYear function, because the test associated with this function were not relevant and would broke on 2022.